### PR TITLE
Add prototype world schema and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CloudFlare Workers Based MUD 
 
+Prototype data files can be found under `data/`, and an overview of the architecture, persistence options, and front-end considerations lives in `docs/architecture.md`.
+
 I'm starting from the workers chat example as it was in reading about this that 
 I even got the idea. Here that example uses separate chat rooms, I'm thinking 
 that is where we will define the map locations. I need to fully wrap my mind 

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,10 @@
+{
+  "stone": {
+    "name": "Small Stone",
+    "description": "A smooth, palm-sized stone. It might be useful for something."
+  },
+  "healing_potion": {
+    "name": "Minor Healing Potion",
+    "description": "Restores a small amount of health when consumed."
+  }
+}

--- a/data/npcs.json
+++ b/data/npcs.json
@@ -1,0 +1,12 @@
+{
+  "rabbit": {
+    "name": "Timid Rabbit",
+    "description": "A small rabbit munching on grass.",
+    "stats": {"hp": 5, "attack": 1}
+  },
+  "town_crier": {
+    "name": "Town Crier",
+    "description": "A loud crier announcing the news.",
+    "stats": {"hp": 20, "attack": 2}
+  }
+}

--- a/data/roll-prompts.json
+++ b/data/roll-prompts.json
@@ -1,0 +1,5 @@
+[
+  {"prompt": "Choose your character's name:"},
+  {"prompt": "Select a class:"},
+  {"prompt": "Select a race:"}
+]

--- a/data/universe.json
+++ b/data/universe.json
@@ -1,0 +1,43 @@
+{
+  "introText": "intro/en.md",
+  "rollPrompts": "data/roll-prompts.json",
+  "classes": [
+    {"id": "warrior", "description": "Excels at melee combat."},
+    {"id": "mage", "description": "Harnesses arcane powers."},
+    {"id": "thief", "description": "Prefers stealth and agility."}
+  ],
+  "races": [
+    {"id": "human", "description": "Balanced and adaptable."},
+    {"id": "elf", "description": "Graceful and attuned to magic."},
+    {"id": "dwarf", "description": "Stout and resilient."}
+  ],
+  "attributes": [
+    "strength",
+    "agility",
+    "intelligence",
+    "constitution"
+  ],
+  "equipLocations": {
+    "head": {"types": ["armor"]},
+    "body": {"types": ["armor"]},
+    "leftHand": {"types": ["weapon", "shield"]},
+    "rightHand": {"types": ["weapon", "shield"]}
+  },
+  "worlds": {
+    "earth": {
+      "realms": {
+        "gaia": {
+          "lands": {
+            "greenfield": {
+              "regions": {
+                "beginner_forest": {
+                  "file": "worlds/earth/realms/gaia/lands/greenfield/regions/beginner_forest.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/worlds/earth/realms/gaia/lands/greenfield/regions/beginner_forest.json
+++ b/data/worlds/earth/realms/gaia/lands/greenfield/regions/beginner_forest.json
@@ -1,0 +1,22 @@
+{
+  "id": "beginner_forest",
+  "name": "Beginner's Forest",
+  "rooms": [
+    {
+      "id": "clearing",
+      "title": "Forest Clearing",
+      "description": "Sunlight pours into a small clearing surrounded by ancient trees.",
+      "exits": {"north": "forest_path"},
+      "items": ["stone"],
+      "npcs": ["rabbit"]
+    },
+    {
+      "id": "forest_path",
+      "title": "Forest Path",
+      "description": "A narrow path winding deeper into the forest.",
+      "exits": {"south": "clearing"},
+      "items": ["healing_potion"],
+      "npcs": ["town_crier"]
+    }
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,26 @@
+# MUD Architecture Overview
+
+## Entity Modeling
+- **Rooms** are the basic units of navigation. Each room contains a description, exits to adjacent rooms, items lying around, and non-player characters (NPCs).
+- **Exits** are directional links (`north`, `south`, etc.) mapping to other room identifiers. Hidden or locked properties can be added later.
+- **Items** are defined separately and referenced by identifier. Items may be placed in rooms or carried by players and NPCs.
+- **NPCs** describe interactive actors with statistics and behaviors. Rooms list the IDs of NPCs present.
+
+## Hierarchical World Structure
+The world is described in nested layers:
+`universe` → `world` → `realm` → `land` → `region` → `room`.
+
+The prototype data files show this relationship:
+- `data/universe.json` points to the `beginner_forest` region file.
+- `data/worlds/earth/realms/gaia/lands/greenfield/regions/beginner_forest.json` defines two rooms, their exits, and the items/NPCs they contain.
+- Supporting definitions live in `data/items.json` and `data/npcs.json`.
+
+## State Persistence Options
+- **Durable Objects** can maintain authoritative state for players or rooms, enabling consistent real-time interactions.
+- **KV Storage** is useful for relatively static data such as world definitions or for snapshotting character progress. Periodic writes or message passing from Durable Objects can keep KV synchronized.
+
+Combining the two allows fast reads of world data from KV while using Durable Objects for mutable state.
+
+## Front-End Visualization Possibilities
+- **HTML5 Canvas**: render text output, simple tile maps, or minimal graphics by consuming the JSON world data and WebSocket events.
+- **Godot Integration**: a Godot client can connect to the Worker WebSocket, parse the same data files, and provide richer visualization or 2D/3D representations while retaining the text-based gameplay options.

--- a/intro/en.md
+++ b/intro/en.md
@@ -1,0 +1,4 @@
+# Welcome to the Realm
+
+Your adventure begins in a humble forest on the outskirts of civilization.
+Prepare to explore, fight, and uncover the mysteries hidden among the trees.


### PR DESCRIPTION
## Summary
- document entity modeling, persistence options, and front-end approaches for a Cloudflare Workers MUD
- prototype universe data hierarchy including a sample region, items, and NPCs

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c4816e508832ca3abce62e0d6d93f